### PR TITLE
Add missing dependency for building pypi pkg 

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,6 +40,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+      - name: Install python build
+        run: pip install build
       - name: Build .wheel package
         run: python -m build
       - name: Upload wheel package


### PR DESCRIPTION
## :earth_americas: Summary
Adds a missing step to install python `build` in the GH workflow used to build pypi package.

