### PR TITLE
Mm/bump package version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -78,8 +78,7 @@ jobs:
 
   github-release:
     needs:
-      - build-conda
-      - build-pypi
+      - publish-to-prefix
     if: startsWith(github.ref, 'refs/tags/')
 
     permissions:


### PR DESCRIPTION
## :earth_americas: Summary
Updated the version of `ecoscope-eda-core` from `0.1.0` to `0.1.1` to re-test the pipeline and be able to generate a GH release

