### PR TITLE
Refactor RunWorkflow command to support match_spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,7 @@ from ecoscope_eda_core.messages import RunWorkflow, RunWorkflowParams
 # Create a command message
 run_workflow_command = RunWorkflow(
     payload=RunWorkflowParams(
-        conda_channel="https://repo.prefix.dev/ecoscope-workflows/",
-        conda_package="events",
-        conda_package_version="1.2.3",
+        match_spec="prefix.dev/ecoscope-workflows::events=0.65.2",
         command="run",
         invoker_kwargs={
             "mock_io": True,

--- a/pixi.toml
+++ b/pixi.toml
@@ -61,7 +61,7 @@ pytest-asyncio = ">=0.26.0,<0.27"
 
 [package]
 name = "ecoscope-eda-core"
-version = "0.1.5"
+version = "0.2.0"
 
 [package.build]
 backend = { name = "pixi-build-python", version = "0.1.*" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ecoscope-eda-core"
-version = "0.1.5"
+version = "0.2.0"
 description = "Common schemas & utilities for event-driven workflows."
 authors = [{ name = "Mariano M", email = "marianom@earthranger.com" }]
 requires-python = ">=3.10,<3.13"

--- a/src/ecoscope_eda_core/messages/commands.py
+++ b/src/ecoscope_eda_core/messages/commands.py
@@ -11,9 +11,7 @@ class InvokerType(str, Enum):
 
 
 class RunWorkflowParams(BaseModel):
-    conda_channel: str = Field(..., title="Conda channel")
-    conda_package: str = Field(..., title="Package name")
-    conda_package_version: str = Field(..., title="Package version")
+    match_spec: str = Field(..., title="Conda match_spec string")
     invoker_type: InvokerType = Field(
         InvokerType.BLOCKING_SUBPROCESS, title="Invoker type"
     )

--- a/src/ecoscope_eda_core/tests/test_publishers.py
+++ b/src/ecoscope_eda_core/tests/test_publishers.py
@@ -15,9 +15,7 @@ async def test_gcp_pubsub_publisher_minimal(mocker, pubsub_client_mock):
     publisher = GCPPubSubPublisher(project="ecoscope-dev")
     run_workflow_command = RunWorkflow(
         payload=RunWorkflowParams(
-            conda_channel="https://repo.prefix.dev/ecoscope-workflows/",
-            conda_package="custom-events-workflow-pkg",
-            conda_package_version="0.0.65",
+            match_spec="prefix.dev/ecoscope-workflows::events=0.65.2",
             command="run",
             invoker_kwargs={
                 "mock_io": True,
@@ -54,9 +52,7 @@ async def test_gcp_pubsub_publisher_minimal_as_async_ctx_mgr(
     async with GCPPubSubPublisher(project="ecoscope-dev") as publisher:
         run_workflow_command = RunWorkflow(
             payload=RunWorkflowParams(
-                conda_channel="https://repo.prefix.dev/ecoscope-workflows/",
-                conda_package="custom-events-workflow-pkg",
-                conda_package_version="0.0.65",
+                match_spec="prefix.dev/ecoscope-workflows::events=0.65.2",
                 command="run",
                 invoker_kwargs={
                     "mock_io": True,
@@ -93,9 +89,7 @@ async def test_gcp_pubsub_publisher_with_attributes(mocker, pubsub_client_mock):
     publisher = GCPPubSubPublisher(project="ecoscope-dev")
     run_workflow_command = RunWorkflow(
         payload=RunWorkflowParams(
-            conda_channel="https://repo.prefix.dev/ecoscope-workflows/",
-            conda_package="custom-events-workflow-pkg",
-            conda_package_version="0.0.65",
+            match_spec="prefix.dev/ecoscope-workflows::events=0.65.2",
             command="run",
             invoker_kwargs={
                 "mock_io": True,
@@ -135,9 +129,7 @@ async def test_gcp_pubsub_publisher_with_custom_timeout(mocker, pubsub_client_mo
     publisher = GCPPubSubPublisher(project="ecoscope-dev")
     run_workflow_command = RunWorkflow(
         payload=RunWorkflowParams(
-            conda_channel="https://repo.prefix.dev/ecoscope-workflows/",
-            conda_package="custom-events-workflow-pkg",
-            conda_package_version="0.0.65",
+            match_spec="prefix.dev/ecoscope-workflows::events=0.65.2",
             command="run",
             invoker_kwargs={
                 "mock_io": True,
@@ -176,9 +168,7 @@ async def test_gcp_pubsub_publisher_retries_on_request_timeout(
     publisher = GCPPubSubPublisher(project="ecoscope-dev")
     run_workflow_command = RunWorkflow(
         payload=RunWorkflowParams(
-            conda_channel="https://repo.prefix.dev/ecoscope-workflows/",
-            conda_package="custom-events-workflow-pkg",
-            conda_package_version="0.0.65",
+            match_spec="prefix.dev/ecoscope-workflows::events=0.65.2",
             command="run",
             invoker_kwargs={
                 "mock_io": True,
@@ -204,9 +194,7 @@ async def test_gcp_pubsub_publisher_retries_on_connect_error(
     publisher = GCPPubSubPublisher(project="ecoscope-dev")
     run_workflow_command = RunWorkflow(
         payload=RunWorkflowParams(
-            conda_channel="https://repo.prefix.dev/ecoscope-workflows/",
-            conda_package="custom-events-workflow-pkg",
-            conda_package_version="0.0.65",
+            match_spec="prefix.dev/ecoscope-workflows::events=0.65.2",
             command="run",
             invoker_kwargs={
                 "mock_io": True,


### PR DESCRIPTION
## :earth_americas: Summary
Closes https://github.com/wildlife-dynamics/compose/issues/776

## :package: Proposed Changes
As discussed with @cisaacstern, this PR refactors the `RunWorkflow` command to use a conda `match_spec` string to specify the target workflow package.

## 📋 Checklist
- [x] Unit tests updated if necessary
- [x] README updated if necessary
- [x] Conda package build tested
- [x] Pypi package build tested
