### PR TITLE
Add Cloud Batch in invokers enum

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -59,7 +59,7 @@ obstore = ">=0.4.0,<0.7"
 
 [package]
 name = "ecoscope-eda-core"
-version = "0.2.1"
+version = "0.2.2"
 
 [package.build]
 backend = { name = "pixi-build-python", version = "0.1.*" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ecoscope-eda-core"
-version = "0.2.1"
+version = "0.2.2"
 description = "Common schemas & utilities for event-driven workflows."
 authors = [{ name = "Mariano M", email = "marianom@earthranger.com" }]
 requires-python = ">=3.10,<3.13"

--- a/src/ecoscope_eda_core/messages/commands.py
+++ b/src/ecoscope_eda_core/messages/commands.py
@@ -7,7 +7,7 @@ from .core import Command
 
 class InvokerType(str, Enum):
     BLOCKING_SUBPROCESS = "BlockingLocalSubprocessInvoker"
-    K8S_JOB = "K8sJobInvoker"
+    CLOUD_BATCH = "CloudBatchInvoker"
 
 
 class RunWorkflowParams(BaseModel):


### PR DESCRIPTION
## :earth_americas: Summary
Closes https://github.com/wildlife-dynamics/ecoscope-eda-core/issues/19

## :package: Proposed Changes
Add the CLOUD_BATCH choice in the invoker types enum, so that it can be used by ecoscope-server and the workflows runner for long workflows

## 📋 Checklist
- ~[ ] Unit tests updated if necessary~
- ~[ ] README updated if necessary~
- [x] Conda package build tested
- [x] Pypi package build tested
