### PR TITLE
elebot: Bump pixi version to v0.50.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PIXI_VERSION: v0.48.0
+  PIXI_VERSION: v0.50.2
 
 jobs:
   lint:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PIXI_VERSION: v0.48.0
+  PIXI_VERSION: v0.50.2
 
 jobs:
   build-conda:


### PR DESCRIPTION
Auto-generated by: https://github.com/wildlife-dynamics/ecoscope-workflows/actions/runs/   <br>Pixi release notes: https://github.com/prefix-dev/pixi/releases/tag/v0.50.2
