### PR TITLE
feat: add `CloudRunJobsSandboxInvoker` to `InvokerType` enum

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -59,7 +59,7 @@ obstore = ">=0.4.0,<0.7"
 
 [package]
 name = "ecoscope-eda-core"
-version = "0.2.2"
+version = "0.2.3"
 
 [package.build]
 backend = { name = "pixi-build-python", version = "0.1.*" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ecoscope-eda-core"
-version = "0.2.2"
+version = "0.2.3"
 description = "Common schemas & utilities for event-driven workflows."
 authors = [{ name = "Mariano M", email = "marianom@earthranger.com" }]
 requires-python = ">=3.10,<3.13"

--- a/src/ecoscope_eda_core/messages/commands.py
+++ b/src/ecoscope_eda_core/messages/commands.py
@@ -8,6 +8,7 @@ from .core import Command
 class InvokerType(str, Enum):
     BLOCKING_SUBPROCESS = "BlockingLocalSubprocessInvoker"
     CLOUD_BATCH = "CloudBatchInvoker"
+    CLOUD_RUN_JOBS_SANDBOX = "CloudRunJobsSandboxInvoker"
 
 
 class RunWorkflowParams(BaseModel):

--- a/src/ecoscope_eda_core/tests/test_commands.py
+++ b/src/ecoscope_eda_core/tests/test_commands.py
@@ -1,0 +1,25 @@
+import pytest
+
+from ..messages.commands import InvokerType, RunWorkflowParams
+
+
+@pytest.mark.parametrize(
+    "value,member",
+    [
+        ("BlockingLocalSubprocessInvoker", InvokerType.BLOCKING_SUBPROCESS),
+        ("CloudBatchInvoker", InvokerType.CLOUD_BATCH),
+        ("CloudRunJobsSandboxInvoker", InvokerType.CLOUD_RUN_JOBS_SANDBOX),
+    ],
+)
+def test_invoker_type_values(value, member):
+    assert InvokerType(value) is member
+
+
+@pytest.mark.parametrize("invoker_type", list(InvokerType))
+def test_run_workflow_params_accepts_all_invoker_types(invoker_type):
+    params = RunWorkflowParams(
+        match_spec="ecoscope-workflows-test==0.1.0",
+        invoker_type=invoker_type.value,
+        command="run",
+    )
+    assert params.invoker_type is invoker_type


### PR DESCRIPTION
## :earth_americas: Summary

Allow RunWorkflow commands to target the new Cloud Run Jobs-based sandbox invoker. Adds unit tests covering all InvokerType values and their acceptance by RunWorkflowParams, and bumps the package version to 0.2.3 in pyproject.toml and pixi.toml.

## :package: Proposed Changes

See above.

## 📋 Checklist
- [x] Unit tests updated if necessary
- [ ] README updated if necessary
- [ ] Conda package build tested
- [ ] Pypi package build tested
