### PR TITLE
Add missing channel to prefix upload command

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Login to prefix.dev
         run: pixi auth login prefix.dev --token ${{ secrets.PREFIX_API_KEY }}
       - name: Publish to prefix.dev
-        run: pixi upload prefix -v https://prefix.dev/api/v1/upload/ecoscope-workflows /tmp/ecoscope-eda-core/conda-release/artifacts/*.conda
+        run: pixi upload prefix -c ecoscope-workflows -v /tmp/ecoscope-eda-core/conda-release/artifacts/*.conda
 
   github-release:
     needs:


### PR DESCRIPTION
## :earth_americas: Summary

Fast-follow to #61 to fix https://github.com/wildlife-dynamics/ecoscope-eda-core/actions/runs/27365733705/job/80864669903

## :package: Proposed Changes

- Adds missing `-c` / `--channel` arg for pixi 0.70.2

## 📋 Checklist
- [ ] Unit tests updated if necessary
- [ ] README updated if necessary
- [ ] Conda package build tested
- [ ] Pypi package build tested
